### PR TITLE
Add offset parameter to rec_load_all

### DIFF
--- a/class_cloudflare.php
+++ b/class_cloudflare.php
@@ -108,11 +108,12 @@ class cloudflare_api
      * 3.3 - Retrieve DNS Records Of A Given Domain
      * This function retrieves the current DNS records for a particular website.
      */
-    public function rec_load_all($domain)
+    public function rec_load_all($domain, $offset = 0)
     {
         $data = array(
             'a' => 'rec_load_all',
-            'z' => $domain
+            'z' => $domain,
+            'o' => $offset
         );
         return $this->http_post($data);
     }


### PR DESCRIPTION
`rec_load_all` returns a paginated results list. This pull request adds an offset parameter so later pages of results can be loaded if needed.

From the cloudflare API docs: https://www.cloudflare.com/docs/client-api.html#s3.3

> If the has_more parameter in the JSON response is true, you can use o=N to offset the starting position for the response. By default, this call will list the first 180 records for a zone.