### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#CloudFlare API PHP Binding
+# CloudFlare API PHP Binding
 
 
 This is a basic PHP binding for the [CloudFlare](https://www.cloudflare.com/) [Client](https://www.cloudflare.com/docs/client-api.html) and [Host](https://www.cloudflare.com/docs/host-api.html) APIs.
@@ -8,17 +8,17 @@ Depending on the number of parameters passed, you can use either the host functi
 A PHP object is returned in all cases.
 
 
-##Client API
+## Client API
 
-###Usage
+### Usage
 
     $cf = new cloudflare_api("me@example.com", "799df833d7a42adf3b8e2fd113c7260b955b8e95ac42c");
     $response = $cf->stats("example.com", $cf::INTERVAL_30_DAYS);
     
 	
-##Host API
+## Host API
 
-###Usage
+### Usage
 
     $cf = new cloudflare_api("8afbe6dea02407989af4dd4c97bb6e25");
     $response = $cf->user_create("newuser@example.com", "newpassword", "", "someuniqueid");


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
